### PR TITLE
fix: publish sweep fails loud on corrupt content, not silent

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,28 @@
+name: offline tests
+
+# gazette had no PR gate: the publish logic shipped untested by CI. This runs the
+# fast, no-secrets, no-live-service subset on every PR so a regression in the
+# publish sweep or the content taxonomy is caught before merge. The live
+# integration tests (Bluesky / Signal / GitHub) still run locally / opt-in until
+# the offline-vs-integration split lands (see ooda test-suite-repair item).
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  offline-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.13"
+      - name: run offline test subset
+        run: |
+          uv run --frozen pytest \
+            pytests/src/dynamicalsystem/pytests/test_publish_failures.py \
+            pytests/src/dynamicalsystem/pytests/test_content_faults.py \
+            pytests/src/dynamicalsystem/pytests/test_watermarks.py \
+            pytests/src/dynamicalsystem/pytests/test_config.py \
+            pytests/src/dynamicalsystem/pytests/test_utils.py \
+            -q

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,10 +1,11 @@
 name: offline tests
 
 # gazette had no PR gate: the publish logic shipped untested by CI. This runs the
-# fast, no-secrets, no-live-service subset on every PR so a regression in the
-# publish sweep or the content taxonomy is caught before merge. The live
-# integration tests (Bluesky / Signal / GitHub) still run locally / opt-in until
-# the offline-vs-integration split lands (see ooda test-suite-repair item).
+# self-contained subset on every PR so a regression in the publish sweep or the
+# content taxonomy is caught before merge. Excluded until the offline-vs-
+# integration split lands (see ooda test-suite-repair item): the Bluesky/Signal/
+# GitHub integration tests (secrets + live services) and test_watermarks/
+# test_environment (which read local on-disk state absent on a fresh runner).
 on:
   pull_request:
   workflow_dispatch:
@@ -22,7 +23,6 @@ jobs:
           uv run --frozen pytest \
             pytests/src/dynamicalsystem/pytests/test_publish_failures.py \
             pytests/src/dynamicalsystem/pytests/test_content_faults.py \
-            pytests/src/dynamicalsystem/pytests/test_watermarks.py \
             pytests/src/dynamicalsystem/pytests/test_config.py \
             pytests/src/dynamicalsystem/pytests/test_utils.py \
             -q

--- a/gazette/src/dynamicalsystem/gazette/__init__.py
+++ b/gazette/src/dynamicalsystem/gazette/__init__.py
@@ -1,43 +1,73 @@
 from dynamicalsystem.gazette.log import logger
 from dynamicalsystem.gazette.publishers import create_publisher
 from dynamicalsystem.gazette.watermarks import watermarks
+from dynamicalsystem.gazette.content import ContentProblem, ReviewNotReady
+from dynamicalsystem.gazette.alerts import send_alert
 
 
 def publish_once() -> int:
     """Run one publish sweep: for each watermark (target), publish the current
-    placing and decrement it on success. Skips targets with no usable review and
-    holds their watermark. Library entry point -- called by the `publish` CLI and
-    (via loop 07) by the systemd timer. Does not touch the web stack.
+    placing and decrement it on success.
+
+    A target with no written review yet (ReviewNotReady) is held quietly -- that
+    fires every run for every unwritten placing and is not a fault. Anything else
+    -- a corrupt or unavailable chart, an invalid review, a failed send, or an
+    unexpected error -- is a FAULT: it is logged loudly, the watermark is held
+    (never advanced past a failure), the sweep continues to the other targets,
+    and the function returns non-zero after alerting the operator. This is what
+    stops a silent, all-target outage from ever looking like a clean run again.
+
+    Library entry point -- called by the `publish` CLI and the systemd timer.
+    Does not touch the web stack.
     """
     marks = watermarks()
     if not marks:
         logger.warning("No watermarks to publish (missing or empty watermark file).")
         return 0
 
+    faults = []
     for watermark in marks:
         try:
             publisher = create_publisher(watermark=watermark)
             if publisher.publish():
                 logger.info(
-                    (
-                        f"Published - {publisher.chart}.{publisher.placing} "
-                        f"on {str(publisher.__class__.__name__)} "
-                        f"with {publisher.watermark.name}."
-                    )
+                    f"Published - {publisher.chart}.{publisher.placing} "
+                    f"on {publisher.__class__.__name__} "
+                    f"with {publisher.watermark.name}."
                 )
                 publisher.watermark.update()
             else:
                 logger.error(
-                    (
-                        f"Publish failed - {publisher.chart}.{publisher.placing} "
-                        f"on {str(publisher.__class__.__name__)} "
-                        f"with {publisher.watermark.name}."
-                    )
+                    f"Publish failed - {publisher.chart}.{publisher.placing} "
+                    f"on {publisher.__class__.__name__} "
+                    f"with {publisher.watermark.name}."
                 )
-        except ValueError as e:  # no review yet / chart complete -- expected
-            # Not a fault: skip this target and hold its watermark. A traceback
-            # here would fire every scheduled run for every unwritten placing.
-            logger.warning(f"{e} Watermark {watermark} -- skipping, watermark held.")
+                faults.append(
+                    f"{watermark}: send failed for "
+                    f"{publisher.chart}.{publisher.placing}"
+                )
+        except ReviewNotReady as e:
+            # benign: the review is not written yet -- hold and try next run
+            logger.info(f"{e} Watermark {watermark} -- not ready, held.")
             continue
+        except ContentProblem as e:
+            # corrupt / unavailable chart, or an invalid review -- a real fault
+            logger.error(f"{e} Watermark {watermark} -- FAULT, held.")
+            faults.append(f"{watermark}: {e}")
+            continue
+        except Exception as e:
+            # never let one odd target silently abort the whole sweep
+            logger.exception(f"Unexpected error on watermark {watermark} -- FAULT, held.")
+            faults.append(f"{watermark}: unexpected {type(e).__name__}: {e}")
+            continue
+
+    if faults:
+        summary = (
+            f"gazette publish: {len(faults)} fault(s) held, nothing advanced "
+            f"for them:\n" + "\n".join(f"- {f}" for f in faults)
+        )
+        logger.error(summary)
+        send_alert(summary)
+        return 1
 
     return 0

--- a/gazette/src/dynamicalsystem/gazette/alerts.py
+++ b/gazette/src/dynamicalsystem/gazette/alerts.py
@@ -1,0 +1,43 @@
+"""Operational alerting for the publish sweep.
+
+Deliberately self-contained: a fault alert must NOT build a Publisher, because
+constructing one fetches a review -- which can fail for the very reason we are
+alerting about. So this posts to the Signal service directly.
+"""
+from requests import post, RequestException
+
+from dynamicalsystem.gazette.config import settings
+from dynamicalsystem.gazette.log import logger
+from dynamicalsystem.gazette.utils import url_join
+
+
+def send_alert(message: str) -> bool:
+    """Push one operational alert to the ops Signal recipient. Best-effort:
+    returns True if delivered, False (with a logged reason) otherwise.
+    """
+    config = settings()
+    target = config.signal_ops_target
+    if not target:
+        logger.error("signal_ops_target unset -- alert not delivered: %s", message)
+        return False
+
+    try:
+        response = post(
+            url_join(config.signal_url, ["v2/send"]),
+            json={
+                "message": message,
+                "number": config.signal_identity,
+                "recipients": [target],
+            },
+            headers={"Content-Type": "application/json"},
+            timeout=30,
+        )
+    except RequestException as e:
+        logger.error("Alert send failed: %s", e)
+        return False
+
+    if not response.ok:
+        logger.error("Alert send rejected: HTTP %s", response.status_code)
+        return False
+
+    return True

--- a/gazette/src/dynamicalsystem/gazette/config.py
+++ b/gazette/src/dynamicalsystem/gazette/config.py
@@ -34,6 +34,11 @@ class Settings(BaseSettings):
     signal_url: str = ""
     signal_identity: str = ""
 
+    # operational alerts: a Signal recipient (number or group id) that gets a
+    # message when a publish sweep holds any fault. Unset -> no alert is sent
+    # (the sweep still exits non-zero). Optional so dev/dry-run stays silent.
+    signal_ops_target: str = ""
+
     # state
     data_folder: str = ""
     watermark_file: str = "watermarks.json"

--- a/gazette/src/dynamicalsystem/gazette/content.py
+++ b/gazette/src/dynamicalsystem/gazette/content.py
@@ -3,6 +3,36 @@ from dynamicalsystem.gazette.utils import url_join
 from dynamicalsystem.gazette.log import logger
 from requests import get, post
 
+VERDICTS = ("Ignore.", "Buy.", "Explore.")
+
+
+class ContentProblem(Exception):
+    """Base: something about the chart or review stops this target publishing."""
+
+
+class ChartUnavailable(ContentProblem):
+    """The chart file could not be fetched (404, auth, network). A FAULT: it
+    hits every target that reads this chart (e.g. an expired PAT)."""
+
+
+class ChartCorrupt(ContentProblem):
+    """The chart fetched but is not valid JSON, or is not a list. A FAULT:
+    one bad character (a dropped comma) breaks the whole chart for every
+    target. This is the case that must never be mistaken for 'not written yet'."""
+
+
+class ReviewNotReady(ContentProblem):
+    """This placing has no usable review yet -- the index is past the end of
+    the chart, or the review/verdict is still blank. Expected and benign:
+    hold the watermark quietly and try again next run."""
+
+
+class ReviewInvalid(ContentProblem):
+    """A written review is malformed -- its verdict is not one of VERDICTS.
+    A FAULT: the review exists but was fat-fingered, so it will never publish
+    until a human fixes it."""
+
+
 class GitHub:
     def __init__(self, chart, placing):
         self.config = settings()
@@ -18,35 +48,44 @@ class GitHub:
 
         response = get(self.url, headers=headers)
 
-        if response.ok:
-            try:
-                item = response.json()[placing-1]
-            except (ValueError) as e:
-                message = f"Bad things for item {placing} in series {chart}."
-                raise ValueError(message) from e
-            except (IndexError, ValueError) as e:
-                message = f"No review found for item {placing} in series {chart}."
-                raise IndexError(message) from e
+        if not response.ok:
+            raise ChartUnavailable(
+                f"Chart {chart} unavailable: HTTP {response.status_code} for {response.url}"
+            )
 
-            self.item = item
-        else:
-            self.logger.error("{response.text} {response.url}")
-            self.item = None        
+        try:
+            data = response.json()
+        except ValueError as e:  # json.JSONDecodeError is a ValueError subclass
+            raise ChartCorrupt(f"Chart {chart} is not valid JSON: {e}") from e
 
-    def validate_content(self):
-        keys = ["artist", "work", "review", "verdict"]
-        verdicts = ["Ignore.", "Buy.", "Explore."]
+        if not isinstance(data, list):
+            raise ChartCorrupt(
+                f"Chart {chart} is not a list (got {type(data).__name__})."
+            )
 
-        # Keys exist
-        if not all(key in self.item for key in keys):
-            return False
+        try:
+            self.item = data[placing - 1]
+        except IndexError as e:
+            raise ReviewNotReady(
+                f"No review yet for item {placing} in chart {chart}."
+            ) from e
 
-        # Values are not empty strings
-        if not all(bool(self.item.get(key)) for key in keys):
-            return False
+    def classify(self) -> str:
+        """Grade the fetched item: 'ok', 'not_ready', or 'invalid'.
 
-        # Verdict is one of the formattable options
-        if not self.item["verdict"] in verdicts:
-            return False
+        'not_ready' (blank/absent review or verdict) is the benign not-written
+        state; 'invalid' (a non-empty verdict outside VERDICTS) is a fault.
+        """
+        keys = ("artist", "work", "review", "verdict")
+        item = self.item
 
-        return True
+        if not isinstance(item, dict) or not all(k in item for k in keys):
+            return "not_ready"
+        if not all(str(item[k]).strip() for k in keys):
+            return "not_ready"
+        if item["verdict"] not in VERDICTS:
+            return "invalid"
+        return "ok"
+
+    def validate_content(self) -> bool:
+        return self.classify() == "ok"

--- a/gazette/src/dynamicalsystem/gazette/publishers.py
+++ b/gazette/src/dynamicalsystem/gazette/publishers.py
@@ -8,12 +8,14 @@ from dynamicalsystem.gazette.log import logger
 from dynamicalsystem.gazette.utils import possessive, url_join
 from dynamicalsystem.gazette.review import Review
 from dynamicalsystem.gazette.watermarks import Watermark
+from dynamicalsystem.gazette.content import ReviewInvalid, ReviewNotReady
 
 
 def create_publisher(watermark: str):
     w = Watermark(watermark)
     if w.placing <= 0:
-        raise ValueError(f"Chart complete for {watermark} (placing={w.placing})")
+        # walked off the end of the chart -- benign, hold quietly
+        raise ReviewNotReady(f"Chart complete for {watermark} (placing={w.placing})")
     _class = globals()[w.publisher]  # todo: this is a bit of a hack
 
     return _class(w)
@@ -29,13 +31,18 @@ class Publisher(abc.ABC):
         self.chart = review.chart
         self.placing = review.placing
 
-        if review.content.validate_content():
+        # Split "not written yet" (benign, hold quietly) from "written wrong"
+        # (a fault). Both skip this target without decrementing its watermark.
+        status = review.content.classify()
+        if status == "ok":
             self.content = review
+        elif status == "invalid":
+            raise ReviewInvalid(
+                f"Review {self.chart}.{self.placing} has an invalid verdict: "
+                f"{review.verdict!r}"
+            )
         else:
-            # No usable review (empty/invalid content). Raise ValueError so
-            # main() skips to the next target WITHOUT decrementing this
-            # watermark -- the placing is retried once the review is written.
-            raise ValueError(f"Content missing for {self.chart}.{self.placing}")
+            raise ReviewNotReady(f"Review {self.chart}.{self.placing} not written yet.")
 
     @abc.abstractmethod
     def publish(self):

--- a/gazette/src/dynamicalsystem/gazette/review.py
+++ b/gazette/src/dynamicalsystem/gazette/review.py
@@ -7,7 +7,10 @@ class Review:
         self.placing = placing
         self.publishers = []
         self.content = GitHub(chart, placing)
-        self.artist = self.content.item["artist"]
-        self.work = self.content.item["work"]
-        self.review = self.content.item["review"]
-        self.verdict = self.content.item["verdict"]
+        # .get, not [] -- a missing key is graded 'not_ready' by classify()
+        # and held quietly, rather than crashing the whole publish sweep.
+        item = self.content.item if isinstance(self.content.item, dict) else {}
+        self.artist = item.get("artist", "")
+        self.work = item.get("work", "")
+        self.review = item.get("review", "")
+        self.verdict = item.get("verdict", "")

--- a/pytests/src/dynamicalsystem/pytests/test_content.py
+++ b/pytests/src/dynamicalsystem/pytests/test_content.py
@@ -39,14 +39,15 @@ def test_verdict_value_is_empty(environment_variables):
     assert not content.validate_content()
 
 def test_github_series_is_missing(environment_variables):
-    from dynamicalsystem.gazette.content import GitHub
+    from dynamicalsystem.gazette.content import GitHub, ChartUnavailable
 
-    content = GitHub("nothing", 100)
-    assert not bool(content.item)
+    # a missing chart file (404) is now a loud fault, not a silent item=None
+    with raises(ChartUnavailable):
+        GitHub("nothing", 100)
 
 def test_github_content_is_missing(environment_variables):
-    from dynamicalsystem.gazette.content import GitHub
+    from dynamicalsystem.gazette.content import GitHub, ReviewNotReady
 
-    with raises(IndexError) as e:
-        _ = GitHub("test", 101)
-        assert e.value == "No review found for item 101 in series test."
+    # a placing past the end of the chart is "not written yet", held quietly
+    with raises(ReviewNotReady):
+        GitHub("test", 101)

--- a/pytests/src/dynamicalsystem/pytests/test_content_faults.py
+++ b/pytests/src/dynamicalsystem/pytests/test_content_faults.py
@@ -1,0 +1,69 @@
+"""content.GitHub taxonomy, offline: requests.get and settings are mocked, so
+these run with no network and pin the exact classification that stopped today's
+silent outage -- a chart that returns 200 but will not parse is CORRUPT, not
+'not written yet'.
+"""
+from json import JSONDecodeError
+from types import SimpleNamespace
+from pytest import raises
+
+import dynamicalsystem.gazette.content as content_mod
+from dynamicalsystem.gazette.content import (
+    GitHub,
+    ChartCorrupt,
+    ChartUnavailable,
+    ReviewNotReady,
+)
+
+
+def _response(ok=True, status=200, json_exc=None, data=None, url="http://t/c.json"):
+    def _json():
+        if json_exc is not None:
+            raise json_exc
+        return data
+
+    return SimpleNamespace(ok=ok, status_code=status, text="", url=url, json=_json)
+
+
+def _patch(monkeypatch, response):
+    monkeypatch.setattr(content_mod, "get", lambda *a, **k: response)
+    monkeypatch.setattr(
+        content_mod,
+        "settings",
+        lambda: SimpleNamespace(github_url="http://t/", github_token=""),
+    )
+
+
+def test_unparseable_chart_is_chartcorrupt(monkeypatch):
+    # HTTP 200 but the body is not valid JSON -- today's dropped-comma incident
+    _patch(monkeypatch, _response(json_exc=JSONDecodeError("Expecting ','", "", 0)))
+    with raises(ChartCorrupt):
+        GitHub("tQ26.H", 98)
+
+
+def test_non_list_chart_is_chartcorrupt(monkeypatch):
+    _patch(monkeypatch, _response(data={"not": "a list"}))
+    with raises(ChartCorrupt):
+        GitHub("tQ26.H", 1)
+
+
+def test_http_error_is_chartunavailable(monkeypatch):
+    # 404 (missing file) or 401 (expired PAT) -- a fault, no longer a silent None
+    _patch(monkeypatch, _response(ok=False, status=404))
+    with raises(ChartUnavailable):
+        GitHub("tQ26.H", 1)
+
+
+def test_placing_past_end_is_reviewnotready(monkeypatch):
+    _patch(monkeypatch, _response(data=[{"artist": "A"}]))  # one item, ask for 5
+    with raises(ReviewNotReady):
+        GitHub("tQ26.H", 5)
+
+
+def test_good_item_is_returned_and_graded(monkeypatch):
+    item = {"artist": "A", "work": "W", "review": "r", "verdict": "Buy."}
+    _patch(monkeypatch, _response(data=[item]))
+    gh = GitHub("tQ26.H", 1)
+    assert gh.item == item
+    assert gh.classify() == "ok"
+    assert gh.validate_content() is True

--- a/pytests/src/dynamicalsystem/pytests/test_publish_failures.py
+++ b/pytests/src/dynamicalsystem/pytests/test_publish_failures.py
@@ -1,66 +1,81 @@
-"""A publish/content failure must skip to the next target WITHOUT advancing
-the failed target's watermark.
+"""Publish-sweep fault semantics (pure unit tests -- Review, the publishers and
+watermarks are mocked, so nothing here touches GitHub, Signal or Bluesky).
 
-Pure unit tests: Review and the publisher/watermark machinery are mocked, so
-nothing here touches GitHub, Signal or Bluesky.
+The contract:
+  - "not written yet" (ReviewNotReady) is held QUIETLY and does not fail the run;
+  - a corrupt/unavailable chart, an invalid review, or a failed send is a FAULT:
+    it holds the watermark (never advances past a failure), keeps going to the
+    other targets, alerts the operator, and makes publish_once() return non-zero.
 """
 from types import SimpleNamespace
 from pytest import raises
 
 
 class _FakeContent:
-    def __init__(self, valid):
-        self._valid = valid
-        self.url = "https://example.test/tQ26.H.json"
+    def __init__(self, status):  # "ok" | "not_ready" | "invalid"
+        self._status = status
+        self.item = {"artist": "A", "work": "W", "review": "r", "verdict": "Buy."}
+
+    def classify(self):
+        return self._status
 
     def validate_content(self):
-        return self._valid
+        return self._status == "ok"
 
 
 class _FakeReview:
-    """Stand-in for review.Review with controllable validity."""
-
-    def __init__(self, chart, placing, valid):
+    def __init__(self, chart, placing, status):
         self.chart = chart
         self.placing = placing
-        self.content = _FakeContent(valid)
-        self.artist = "Artist" if valid else ""
-        self.work = "Work" if valid else ""
-        self.review = "review" if valid else ""
-        self.verdict = "Buy." if valid else ""
+        self.content = _FakeContent(status)
+        self.artist = "A"
+        self.work = "W"
+        self.review = "r"
+        self.verdict = "Buy." if status != "invalid" else "Buy"
 
 
 def _watermark(name="abyss", chart="tQ26.H", placing=100):
     return SimpleNamespace(name=name, chart=chart, placing=placing, target="dev")
 
 
-def test_invalid_content_raises_valueerror(monkeypatch):
-    """The fix: an unwritten review makes publisher construction raise
-    ValueError (the signal main() uses to skip without updating)."""
+def _patch_review(monkeypatch, status):
     from dynamicalsystem.gazette import publishers
 
     monkeypatch.setattr(
         publishers,
         "Review",
-        lambda chart, placing: _FakeReview(chart, placing, valid=False),
+        lambda chart, placing: _FakeReview(chart, placing, status),
     )
-
-    with raises(ValueError):
-        publishers.Validator(_watermark())
 
 
 def test_valid_content_constructs(monkeypatch):
-    """Guard: valid content still constructs a publisher and keeps the review."""
     from dynamicalsystem.gazette import publishers
 
-    monkeypatch.setattr(
-        publishers,
-        "Review",
-        lambda chart, placing: _FakeReview(chart, placing, valid=True),
-    )
-
+    _patch_review(monkeypatch, "ok")
     p = publishers.Validator(_watermark())
     assert p.content.verdict == "Buy."
+
+
+def test_not_ready_raises_reviewnotready(monkeypatch):
+    """An unwritten review makes construction raise ReviewNotReady -- the quiet
+    signal publish_once() uses to hold the watermark without failing the run."""
+    from dynamicalsystem.gazette import publishers
+    from dynamicalsystem.gazette.content import ReviewNotReady
+
+    _patch_review(monkeypatch, "not_ready")
+    with raises(ReviewNotReady):
+        publishers.Validator(_watermark())
+
+
+def test_invalid_verdict_raises_reviewinvalid(monkeypatch):
+    """A written-but-malformed review (bad verdict) is a fault, distinct from
+    'not written yet'."""
+    from dynamicalsystem.gazette import publishers
+    from dynamicalsystem.gazette.content import ReviewInvalid
+
+    _patch_review(monkeypatch, "invalid")
+    with raises(ReviewInvalid):
+        publishers.Validator(_watermark())
 
 
 def _fake_publisher(name, ok):
@@ -73,28 +88,56 @@ def _fake_publisher(name, ok):
     return p
 
 
-def test_main_continues_past_failures_without_updating(monkeypatch):
-    """The invariant: a content failure (raise) and a publish failure (False)
-    are both skipped, the loop reaches later targets, and neither failed
-    target's watermark is decremented."""
+def test_not_ready_is_quiet_and_run_stays_clean(monkeypatch):
+    """A not-ready target and a successful target: the run is clean (rc 0), no
+    alert, the good target advances, the not-ready one is untouched."""
     import dynamicalsystem.gazette as gazette
+    from dynamicalsystem.gazette.content import ReviewNotReady
 
-    failer = _fake_publisher("failer", ok=False)
     good = _fake_publisher("good", ok=True)
+    alerts = []
 
     def fake_create(watermark):
-        if watermark == "empty":
-            raise ValueError("Content missing for tQ26.H.100")
-        return {"failer": failer, "good": good}[watermark]
+        if watermark == "notready":
+            raise ReviewNotReady("not written yet")
+        return {"good": good}[watermark]
 
-    # order matters: the failures come first, so a working `good` at the end
-    # proves the loop was not aborted by them.
-    monkeypatch.setattr(gazette, "watermarks", lambda: ["empty", "failer", "good"])
+    monkeypatch.setattr(gazette, "watermarks", lambda: ["notready", "good"])
     monkeypatch.setattr(gazette, "create_publisher", fake_create)
+    monkeypatch.setattr(gazette, "send_alert", lambda msg: alerts.append(msg))
 
     rc = gazette.publish_once()
 
-    assert rc == 0                    # no crash
-    assert good.updated is True       # loop reached the later target and advanced it
-    assert failer.updated is False    # publish()->False did not decrement
-    # the "empty" target raised before any watermark existed -> nothing to update
+    assert rc == 0
+    assert good.updated is True
+    assert alerts == []  # quiet: not-ready is not a fault
+
+
+def test_faults_are_loud_hold_and_do_not_abort(monkeypatch):
+    """A corrupt chart and a failed send are both faults: the sweep continues to
+    the good target (which advances), neither faulted watermark is decremented,
+    exactly one alert is sent, and rc is non-zero."""
+    import dynamicalsystem.gazette as gazette
+    from dynamicalsystem.gazette.content import ChartCorrupt
+
+    failer = _fake_publisher("failer", ok=False)  # send returns False -> fault
+    good = _fake_publisher("good", ok=True)
+    alerts = []
+
+    def fake_create(watermark):
+        if watermark == "corrupt":
+            raise ChartCorrupt("tQ26.H is not valid JSON")
+        return {"failer": failer, "good": good}[watermark]
+
+    # corrupt + failed-send come first; a working `good` last proves no abort.
+    monkeypatch.setattr(gazette, "watermarks", lambda: ["corrupt", "failer", "good"])
+    monkeypatch.setattr(gazette, "create_publisher", fake_create)
+    monkeypatch.setattr(gazette, "send_alert", lambda msg: alerts.append(msg))
+
+    rc = gazette.publish_once()
+
+    assert rc == 1                    # loud: the run failed
+    assert good.updated is True       # reached and advanced the later target
+    assert failer.updated is False    # a failed send did not decrement
+    assert len(alerts) == 1           # one summary alert for the whole sweep
+    assert "corrupt" in alerts[0] and "failer" in alerts[0]


### PR DESCRIPTION
## Why

This morning's 07:00 publish skipped all four targets and exited 0 with no alert. Root cause was two-layered: a hand-edit dropped a comma in `tQ26.H.json` (fixed at source in content#2), **and** gazette could not tell a corrupt chart from an unwritten one. `content.py` re-raised the `json.loads` failure as a plain `ValueError`, and `publish_once` treats `ValueError` as the benign "review not written yet" skip -- so whole-chart corruption produced no error, no alert, exit 0.

This is Gate 2 of two (defence in depth). Gate 1 (source-side CI in the content repo, content#2) stops the bad data; this makes gazette **loud** if anything corrupt ever reaches it anyway.

## What

Split the one swallowing `ValueError` into a `ContentProblem` taxonomy:

| Exception | Cause | Behaviour |
|---|---|---|
| `ReviewNotReady` | index past end, blank review/verdict, chart complete | **quiet** hold -- the only non-failing skip |
| `ChartCorrupt` | 200 but unparseable / not a list | fault |
| `ChartUnavailable` | 404 / auth (e.g. expired PAT) | fault |
| `ReviewInvalid` | verdict not one of `Ignore./Buy./Explore.` | fault |

A **fault** logs at ERROR, holds the watermark (never advances past a failure), lets the sweep finish the other targets, sends **one** Signal alert to a new `signal_ops_target`, and returns **non-zero** (systemd then shows the unit failed).

Also fixed along the way:
- `GitHub` now raises `ChartUnavailable` on a non-ok response instead of `item=None` (which crashed downstream via `None['artist']`).
- `Review` reads the item with `.get`, so a missing key is graded not-ready rather than crashing the sweep.
- a catch-all in the sweep means one odd target can never silently abort it.
- `alerts.send_alert` is self-contained (raw `/v2/send`, no `Publisher`) so it cannot fail for the very reason it is reporting.

## Verified

- full suite: **41 passed** (incl. live Bluesky/Signal + public-GitHub content tests)
- new offline tests pin the taxonomy (`test_content_faults.py`) and the sweep semantics (`test_publish_failures.py`)
- reproduced today's exact 200-but-unparseable case end-to-end against the real `publish_once()` -> `rc=1` + alert, where before it was exit 0 silent

## Deploy follow-up (not in this PR)

For prod to actually send the ping, set `SIGNAL_OPS_TARGET` in the on-box `gazette.env` (tinsnip). Without it the sweep still exits non-zero (unit shows failed) but no Signal message goes out. Recommend pointing it at your own number or a dedicated ops group.